### PR TITLE
Separate executeAsync() in ExecutionHandler

### DIFF
--- a/db-scheduler/pom.xml
+++ b/db-scheduler/pom.xml
@@ -21,7 +21,7 @@
         <equals-verifier.version>3.10</equals-verifier.version>
         <bytebuddy.version>1.12.8</bytebuddy.version>
         <micro-jdbc.version>0.3</micro-jdbc.version>
-        <otj-pg-embedded.version>0.11.4</otj-pg-embedded.version>
+        <otj-pg-embedded.version>1.0.1</otj-pg-embedded.version>
         <postgresql.version>42.3.3</postgresql.version>
         <slf4j.version>1.7.36</slf4j.version>
         <test.excludedTags>compatibility</test.excludedTags>

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Executor.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/Executor.java
@@ -99,4 +99,8 @@ public class Executor {
             LOG.warn("Released execution was not found in collection of executions currently being processed. Should never happen. Execution-id: " + executionId);
         }
     }
+
+    public ExecutorService getExecutorService() {
+        return executorService;
+    }
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/SchedulerBuilder.java
@@ -75,6 +75,8 @@ public class SchedulerBuilder {
     protected boolean logStackTrace = LOG_STACK_TRACE_ON_FAILURE;
     private boolean registerShutdownHook = false;
 
+    protected boolean enableAsyncHandler = false;
+
     public SchedulerBuilder(DataSource dataSource, List<Task<?>> knownTasks) {
         this.dataSource = dataSource;
         this.knownTasks.addAll(knownTasks);
@@ -184,6 +186,11 @@ public class SchedulerBuilder {
         return this;
     }
 
+    public SchedulerBuilder enableAsyncHandler() {
+        this.enableAsyncHandler = true;
+        return this;
+    }
+
     public Scheduler build() {
         if (schedulerName == null) {
              schedulerName = new SchedulerName.Hostname();
@@ -209,7 +216,7 @@ public class SchedulerBuilder {
 
         final Scheduler scheduler = new Scheduler(clock, schedulerTaskRepository, clientTaskRepository, taskResolver, executorThreads, candidateExecutorService,
             schedulerName, waiter, heartbeatInterval, enableImmediateExecution, statsRegistry, pollingStrategyConfig,
-            deleteUnresolvedAfter, shutdownMaxWait, logLevel, logStackTrace, startTasks);
+            deleteUnresolvedAfter, shutdownMaxWait, logLevel, logStackTrace, startTasks, enableAsyncHandler);
 
         if (registerShutdownHook) {
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/ExecutionHandler.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/ExecutionHandler.java
@@ -15,6 +15,12 @@
  */
 package com.github.kagkarlsson.scheduler.task;
 
+import java.util.concurrent.CompletableFuture;
+
 public interface ExecutionHandler<T> {
     CompletionHandler<T> execute(TaskInstance<T> taskInstance, ExecutionContext executionContext);
+
+    default CompletableFuture<CompletionHandler<T>> executeAsync(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
+        return CompletableFuture.completedFuture(new CompletionHandler.OnCompleteRemove<>());
+    }
 }

--- a/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/Tasks.java
+++ b/db-scheduler/src/main/java/com/github/kagkarlsson/scheduler/task/helper/Tasks.java
@@ -20,6 +20,7 @@ import com.github.kagkarlsson.scheduler.task.schedule.Schedule;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 public class Tasks {
@@ -266,6 +267,11 @@ public class Tasks {
                 @Override
                 public CompletionHandler<T> execute(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
                     return executionHandler.execute(taskInstance, executionContext);
+                }
+
+                @Override
+                public CompletableFuture<CompletionHandler<T>> executeAsync(TaskInstance<T> taskInstance, ExecutionContext executionContext) {
+                    return executionHandler.executeAsync(taskInstance, executionContext);
                 }
             };
         }


### PR DESCRIPTION
Separate executeAsync() in ExecutionHandler to allow users to remain code unchanged if not turning enableAsyncHandler on. Should write tests for future-based version.